### PR TITLE
Server now starts the file transfer queue in a separate thread

### DIFF
--- a/minibot/plexBot.py
+++ b/minibot/plexBot.py
@@ -24,9 +24,6 @@ def parse_arguments():
                         required=False, action='store_true',
                         help='Run flask server listening at endpoint for new '
                              'movies to sync.')
-    parser.add_argument('-t', '--transfer', dest='transfer',
-                        required=False, action='store_true',
-                        help='Loop the file transfer queue.')
     args = parser.parse_args()
 
     return args, parser
@@ -38,13 +35,11 @@ def main():
     if args.sync_server:
         logger.info('Starting server')
         from utilities import server
-
         server.run_server(debug=args.debug)
 
     elif args.path and args.imdb_guid:
         logger.info('Sending sync request')
         from utilities import server
-
         server.post_new_movie_to_syncer(
                 imdb_guid=args.imdb_guid, path=args.path)
 
@@ -52,12 +47,6 @@ def main():
         logger.info('Sending new movie notification')
         from utilities import plexutils
         plexutils.send_new_movie_slack_notification(args)
-
-    elif args.transfer:
-        logger.info('Starting queue...')
-        from utilities import db_utils, filesyncer
-
-        filesyncer.transfer_queue_loop(db_utils.FileTransferDB())
 
     else:
         parser.print_help()

--- a/minibot/utilities/db_utils.py
+++ b/minibot/utilities/db_utils.py
@@ -106,6 +106,12 @@ class FileTransferDB(object):
         self._update_status(guid, 'queued', 0)
         self._update_status(guid, 'complete', 0)
 
+    def remove_guid(self, guid):
+        with sql.connect(self.db_path) as con:
+            cur = con.cursor()
+            cur.execute("DELETE FROM {} WHERE guid=?".format(
+                self.table_name), (guid,))
+
     @staticmethod
     def row_to_dict(row):
         row_id, guid, remote_path, queued, complete = row

--- a/minibot/utilities/schema.sql
+++ b/minibot/utilities/schema.sql
@@ -1,6 +1,6 @@
 create table if not exists remote_movies (
     id integer primary key autoincrement,
-    guid text not null,
+    guid text unique not null,
     remote_path text not null,
     queued integer default 0,
     complete integer default 0

--- a/minibot/utilities/utils.py
+++ b/minibot/utilities/utils.py
@@ -4,6 +4,7 @@ import math
 import time
 import os.path
 import functools
+import threading
 
 
 class Logger(object):
@@ -74,6 +75,21 @@ class Logger(object):
                                   '{} \n{}'.format(file_path, e))
 
         return file_path
+
+
+class StoppableThread(threading.Thread):
+    """Thread class with a stop() method. The thread itself has to check
+    regularly for the stopped() condition."""
+
+    def __init__(self, *args, **kwargs):
+        super(StoppableThread, self).__init__(*args, **kwargs)
+        self._stop_event = threading.Event()
+
+    def stop(self):
+        self._stop_event.set()
+
+    def stopped(self):
+        return self._stop_event.is_set()
 
 
 def conv_millisec_to_min(milliseconds):


### PR DESCRIPTION
* Added StopableThread class to utils.py
* If queue fails, it will cleanly exit by marking any incomplete items as unqueued
* Transfers that fail after all retries are removed from database
* If the transfer thread dies, it will be restarted when a new request is received
* Schema now requires guid to be unique
* Adopted global logger in filesyncer
* Added `FileTransferDB.remove_guid(self, guid)` to db_utils