### PR TITLE
Bugfix/omdb unicode fix

### DIFF
--- a/minibot/utilities/dbutils.py
+++ b/minibot/utilities/dbutils.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python -u
 # encoding: utf-8
+
 import os.path
 import sqlite3 as sql
 

--- a/minibot/utilities/dbutils.py
+++ b/minibot/utilities/dbutils.py
@@ -35,6 +35,7 @@ class FileTransferDB(object):
             add_movie_sql = 'INSERT INTO {} (guid, remote_path) ' \
                             'VALUES (?, ?)'.format(self.table_name)
             con.row_factory = sql.Row
+            con.text_factory = lambda x: unicode(x, 'utf-8', 'ignore')
             cur = con.cursor()
             cur.execute(add_movie_sql, (guid, remote_path))
             con.commit()
@@ -44,6 +45,7 @@ class FileTransferDB(object):
             self.table_name, query)
         with sql.connect(self.db_path) as con:
             con.row_factory = sql.Row
+            con.text_factory = lambda x: unicode(x, 'utf-8', 'ignore')
             cur = con.cursor()
             cur.execute(query_sql)
 
@@ -54,6 +56,7 @@ class FileTransferDB(object):
             self.table_name)
         with sql.connect(self.db_path) as con:
             con.row_factory = sql.Row
+            con.text_factory = lambda x: unicode(x, 'utf-8', 'ignore')
             cur = con.cursor()
             cur.execute(guid_query, (guid,))
             result = cur.fetchone()
@@ -64,6 +67,7 @@ class FileTransferDB(object):
         query_sql = 'SELECT * FROM {}'.format(self.table_name)
         with sql.connect(self.db_path) as con:
             con.row_factory = sql.Row
+            con.text_factory = lambda x: unicode(x, 'utf-8', 'ignore')
             cur = con.cursor()
             cur.execute(query_sql)
             rows = cur.fetchall()

--- a/minibot/utilities/filesyncer.py
+++ b/minibot/utilities/filesyncer.py
@@ -260,9 +260,10 @@ class PlexSyncer(object):
             return None
 
         try:
-            title_year = u'{} ({})'.format(result["Title"], result["Year"])
+            title_year = u'{} ({})'.format(result[u'Title'], result[u'Year'])
+            logger.debug(u' * title_year: {}'.format(title_year))  # ToDo: Remove debug log
         except Exception as e:
-            logger.error('Failed to determine title and year: {}'.format(e))
+            logger.error(u'Failed to determine title and year: {}'.format(e))
             return None
 
         return title_year

--- a/minibot/utilities/filesyncer.py
+++ b/minibot/utilities/filesyncer.py
@@ -261,7 +261,7 @@ class PlexSyncer(object):
 
         try:
             title_year = u'{} ({})'.format(result[u'Title'], result[u'Year'])
-            logger.debug(u' * title_year: {}'.format(title_year))  # ToDo: Remove debug log
+            logger.debug(u'Title and year: {}'.format(title_year))
         except Exception as e:
             logger.error(u'Failed to determine title and year: {}'.format(e))
             return None

--- a/minibot/utilities/filesyncer.py
+++ b/minibot/utilities/filesyncer.py
@@ -253,14 +253,14 @@ class PlexSyncer(object):
             imdb_guid = self.imdb_guid
         status, result = self._omdb.search(imdb_guid=imdb_guid)
 
-        logger.debug('Response from OMDb: [{}] {}'.format(status, result))
+        logger.debug(u'Response from OMDb: [{}] {}'.format(status, result))
         if not status == 200:
             logger.error(
-                'Non-200 response from OMDb: [{}] {}'.format(status, result))
+                u'Non-200 response from OMDb: [{}] {}'.format(status, result))
             return None
 
         try:
-            title_year = '{} ({})'.format(result["Title"], result["Year"])
+            title_year = u'{} ({})'.format(result["Title"], result["Year"])
         except Exception as e:
             logger.error('Failed to determine title and year: {}'.format(e))
             return None

--- a/minibot/utilities/plexutils.py
+++ b/minibot/utilities/plexutils.py
@@ -236,11 +236,10 @@ def send_new_movie_slack_notification(args):
         debug=args.debug,
         auth_type=config.PLEX_AUTH_TYPE
     )
+    logger.debug(movie_json)
 
     channel = config.DEFAULT_SLACK_ROOM
-
     if args.debug or args.dryrun:
-        logger.debug(movie_json)
         channel = config.DEBUG_SLACK_ROOM
 
     logger.info('Sending to slack_announce')


### PR DESCRIPTION
Previously, unicode characters in responses from OMDb could result in a text encoding exception.
* Now using unicode strings in filesyncer when handling responses from OMDb
* Using unicode text_factory in database handler
* Several logging changes